### PR TITLE
Fix hardcoded version number in pingScaffoldKit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/dev/scaffoldkit/mcp/tools/SystemPingTool.java
+++ b/src/main/java/dev/scaffoldkit/mcp/tools/SystemPingTool.java
@@ -1,13 +1,30 @@
 package dev.scaffoldkit.mcp.tools;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SystemPingTool {
 
+    private static final String VERSION = loadVersion();
+
+    private static String loadVersion() {
+        try (InputStream is = new ClassPathResource("version.properties").getInputStream()) {
+            Properties props = new Properties();
+            props.load(is);
+            return props.getProperty("app.version", "unknown");
+        } catch (IOException e) {
+            return "unknown";
+        }
+    }
+
     @McpTool(description = "Ping the ScaffoldKit MCP bridge to verify it is active and responding.")
     public String pingScaffoldKit() {
-        return "ScaffoldKit MCP DevTools (v0.0.1) are active, loaded, and awaiting commands.";
+        return "ScaffoldKit MCP DevTools (v" + VERSION + ") are active, loaded, and awaiting commands.";
     }
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+app.version=${project.version}


### PR DESCRIPTION
## Summary
Fix hardcoded version number in pingScaffoldKit method to use the project version from pom.xml, set at compile time.

## Changes
- Add Maven resource filtering to pom.xml for compile-time variable substitution
- Create version.properties file with  placeholder
- Update SystemPingTool to read version from properties file at runtime
- Version now matches project version from pom.xml (set at compile time)

## Testing
- ✅ Project compiles successfully
- ✅ version.properties in target/classes contains app.version=0.0.1-SNAPSHOT (from pom.xml)
- ✅ JAR file includes properly filtered version.properties
- ✅ Version is set at compile time (Maven filters resources during build)

Closes #7