### PR TITLE
fix: improve log tool efficiency by using backward reading

### DIFF
--- a/src/main/java/dev/scaffoldkit/mcp/tools/ApplicationLogTool.java
+++ b/src/main/java/dev/scaffoldkit/mcp/tools/ApplicationLogTool.java
@@ -1,8 +1,7 @@
 package dev.scaffoldkit.mcp.tools;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.FileAppender;
-import dev.scaffoldkit.mcp.config.McpProperties;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -10,17 +9,15 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.FileAppender;
 
 @Component
 @Profile("dev")
 class ApplicationLogTool {
     private final Environment env;
-    private final McpProperties properties;
 
-    ApplicationLogTool(McpProperties properties , Environment env) {
-        this.properties = properties;
+    ApplicationLogTool(Environment env) {
         this.env = env;
     }
 

--- a/src/main/java/dev/scaffoldkit/mcp/tools/ApplicationLogTool.java
+++ b/src/main/java/dev/scaffoldkit/mcp/tools/ApplicationLogTool.java
@@ -34,28 +34,102 @@ class ApplicationLogTool {
             Path path = Path.of(logPath);
             if (!Files.exists(path)) return "Log file not found: " + logPath;
 
-            long fileSize = Files.size(path);
-            long maxSize = properties.getTools().getLogTailer().getMaxSize().toBytes();
+            String content = readLastLines(path, lines);
+            if (content.startsWith("Error")) return content;
 
-            if(fileSize > maxSize) {
-                // Use Files.readAllLines but limit the number of lines read
-                var allLines = Files.readAllLines(path);
-                int start = Math.max(0, allLines.size() - lines);
-                var recentLines = allLines.subList(start, allLines.size());
-                StringBuilder sb = new StringBuilder();
-                String note = String.format("[SYSTEM NOTE: Log file is %d MB and has been truncated. Displaying the last %d lines only.]\n", fileSize / (1024 * 1024), lines);
-                sb.append(note).append("=".repeat(80)).append("\n");
-                recentLines.forEach(l -> sb.append(l).append("\n"));
-                return sb.toString();
+            // Count actual lines returned (handle empty content)
+            int actualLines = content.isEmpty() ? 0 : (int) content.lines().count();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Last ").append(actualLines).append(" lines from: ").append(logPath).append("\n");
+            sb.append("=".repeat(80)).append("\n");
+            sb.append(content);
+            return sb.toString();
+        } catch (Exception e) {
+            return "Error reading log file: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Reads the last N lines from a file efficiently by reading from the end.
+     * Uses an iterative approach to read larger chunks until enough lines are found.
+     */
+    private String readLastLines(Path path, int lines) {
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(path.toFile(), "r")) {
+            long length = raf.length();
+            if (length == 0) return "";
+
+            // Start with a reasonable chunk size (estimated 200 bytes per line)
+            int chunkSize = lines * 200;
+            int minChunkSize = 4096; // At least 4KB
+            chunkSize = Math.max(chunkSize, minChunkSize);
+            
+            // Cap maximum iterations to prevent infinite loops
+            int maxIterations = 10;
+            int iteration = 0;
+            
+            while (iteration < maxIterations) {
+                iteration++;
+                long startPointer = Math.max(0, length - chunkSize);
+                raf.seek(startPointer);
+                
+                byte[] buffer = new byte[(int) (length - startPointer)];
+                raf.readFully(buffer);
+                String content = new String(buffer, java.nio.charset.StandardCharsets.UTF_8);
+                
+                // Count newlines to determine how many lines we have
+                // Use simple newline counting for both \n and \r\n
+                int newlineCount = 0;
+                for (int i = 0; i < content.length(); i++) {
+                    char c = content.charAt(i);
+                    if (c == '\n') {
+                        newlineCount++;
+                    }
+                }
+                
+                // If we started from position > 0, the first "line" is likely incomplete
+                // Skip it to avoid partial lines by reducing the count
+                int availableLines = newlineCount;
+                if (startPointer > 0) {
+                    availableLines--;
+                }
+                
+                // Check if we have enough lines or we've read the whole file
+                if (availableLines >= lines || startPointer == 0) {
+                    // Split the content and extract the lines we need
+                    java.util.List<String> linesList = new java.util.ArrayList<>();
+                    String[] parts = content.split("\r?\n");
+                    
+                    // If we started from position > 0, skip the first element (partial line)
+                    int startIndex = (startPointer > 0) ? 1 : 0;
+                    
+                    // Collect lines from the end
+                    for (int i = parts.length - 1; i >= startIndex && linesList.size() < lines; i--) {
+                        linesList.add(0, parts[i]);
+                    }
+                    
+                    // Build result
+                    StringBuilder sb = new StringBuilder();
+                    for (String line : linesList) {
+                        sb.append(line).append("\n");
+                    }
+                    return sb.toString();
+                }
+                
+                // Need more data - double the chunk size
+                chunkSize = chunkSize * 2;
+                // Don't exceed file length
+                chunkSize = (int) Math.min(chunkSize, length);
             }
             
-            var allLines = Files.readAllLines(path);
-            int start = Math.max(0, allLines.size() - lines);
-            var recentLines = allLines.subList(start, allLines.size());
+            // Fallback: read the entire file if we couldn't get enough lines
+            String allContent = Files.readString(path);
+            String[] allLines = allContent.split("\r?\n");
             StringBuilder sb = new StringBuilder();
-            sb.append("Last ").append(recentLines.size()).append(" lines from: ").append(logPath).append("\n");
-            sb.append("=".repeat(80)).append("\n");
-            recentLines.forEach(l -> sb.append(l).append("\n"));
+            int start = Math.max(0, allLines.length - lines);
+            for (int i = start; i < allLines.length; i++) {
+                sb.append(allLines[i]).append("\n");
+            }
             return sb.toString();
         } catch (Exception e) {
             return "Error reading log file: " + e.getMessage();

--- a/src/test/java/dev/scaffoldkit/mcp/tools/ApplicationLogToolTest.java
+++ b/src/test/java/dev/scaffoldkit/mcp/tools/ApplicationLogToolTest.java
@@ -15,10 +15,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.env.Environment;
-import org.springframework.util.unit.DataSize;
 
 import dev.scaffoldkit.mcp.config.McpProperties;
-import dev.scaffoldkit.mcp.config.McpProperties.Tools.LogTailer;
 
 /**
  * Unit tests for {@link ApplicationLogTool}.
@@ -181,79 +179,11 @@ class ApplicationLogToolTest {
     }
 
     @Test
-    @DisplayName("Should return truncation message when file size exceeds maxSize")
-    void getRecentLogs_WhenFileSizeExceedsMaxSize_ReturnsTruncationMessage() throws IOException {
-        // Arrange
-        Path testFile = tempDir.resolve("test.log");
-        createTestFile(testFile, 100, "Log line ");
-        
-        LogTailer logTailer = new LogTailer();
-        // Set maxSize to a very small value to ensure it's smaller than the actual file
-        logTailer.setMaxSize(DataSize.ofBytes(10));
-        properties.getTools().setLogTailer(logTailer);
-        
-        when(environment.getProperty("logging.file.name")).thenReturn(testFile.toString());
-
-        // Act
-        String result = applicationLogTool.getRecentLogs(10);
-
-        // Assert
-        assertTrue(result.contains("[SYSTEM NOTE: Log file is 0 MB and has been truncated. Displaying the last 10 lines only.]"));
-        assertTrue(result.contains("=".repeat(80)));
-        verify(environment).getProperty("logging.file.name");
-    }
-
-    @Test
-    @DisplayName("Should return requested lines when file size exceeds maxSize")
-    void getRecentLogs_WhenFileSizeExceedsMaxSize_ReturnsRequestedLinesNotMore() throws IOException {
-        // Arrange - Create a file with more lines than requested
-        Path testFile = tempDir.resolve("test.log");
-        createTestFile(testFile, 200, "Log line ");
-        
-        // Set maxSize to a very small value to trigger large file behavior
-        LogTailer logTailer = new LogTailer();
-        logTailer.setMaxSize(DataSize.ofBytes(10));
-        properties.getTools().setLogTailer(logTailer);
-        
-        when(environment.getProperty("logging.file.name")).thenReturn(testFile.toString());
-
-        // Act
-        String result = applicationLogTool.getRecentLogs(15);
-
-        // Assert
-        // Should contain truncation message
-        assertTrue(result.contains("[SYSTEM NOTE: Log file is 0 MB and has been truncated. Displaying the last 15 lines only.]"));
-        
-        // Count the number of log lines (excluding header and separator)
-        long logLineCount = result.lines()
-            .filter(line -> line.startsWith("Log line "))
-            .count();
-        
-        // Should return exactly 15 lines, not more
-        assertEquals(15, logLineCount, "Should return exactly 15 lines when file size exceeds maxSize");
-        
-        // Should not contain early lines (use complete line to avoid substring matches)
-        assertFalse(result.lines().anyMatch(line -> line.equals("Log line 1")));
-        assertFalse(result.lines().anyMatch(line -> line.equals("Log line 50")));
-        
-        // Should contain the last lines
-        assertTrue(result.lines().anyMatch(line -> line.equals("Log line 186")));
-        assertTrue(result.lines().anyMatch(line -> line.equals("Log line 200")));
-        
-        verify(environment).getProperty("logging.file.name");
-    }
-
-    @Test
-    @DisplayName("Should return exactly requested lines from large file regardless of maxSize")
+    @DisplayName("Should return exactly requested lines from large file")
     void getRecentLogs_LargeFile_ReturnsExactlyRequestedLines() throws IOException {
         // Arrange - Test with different line counts
         Path testFile = tempDir.resolve("test.log");
         createTestFile(testFile, 500, "Line ");
-        
-        LogTailer logTailer = new LogTailer();
-        // Set maxSize to a very small value to ensure it's smaller than the actual file
-        logTailer.setMaxSize(DataSize.ofBytes(10));
-        properties.getTools().setLogTailer(logTailer);
         
         when(environment.getProperty("logging.file.name")).thenReturn(testFile.toString());
 
@@ -265,7 +195,7 @@ class ApplicationLogToolTest {
             .filter(line -> line.startsWith("Line "))
             .count();
         
-        assertEquals(25, logLineCount, "Should return exactly 25 lines when file size exceeds maxSize");
+        assertEquals(25, logLineCount, "Should return exactly 25 lines from large file");
         
         // Verify the lines are from the end of the file
         assertTrue(result.contains("Line 476"));
@@ -360,54 +290,6 @@ class ApplicationLogToolTest {
 
         // Assert
         assertTrue(result.contains("Log file not found"));
-        verify(environment).getProperty("logging.file.name");
-    }
-
-    @Test
-    @DisplayName("Should handle file with exactly maxSize bytes")
-    void getRecentLogs_WhenFileSizeEqualsMaxSize_ReturnsContent() throws IOException {
-        // Arrange
-        Path testFile = tempDir.resolve("test.log");
-        createTestFile(testFile, 10, "Line ");
-        
-        LogTailer logTailer = new LogTailer();
-        long exactSize = Files.size(testFile);
-        logTailer.setMaxSize(DataSize.ofBytes(exactSize));
-        properties.getTools().setLogTailer(logTailer);
-        
-        when(environment.getProperty("logging.file.name")).thenReturn(testFile.toString());
-
-        // Act
-        String result = applicationLogTool.getRecentLogs(5);
-
-        // Assert
-        // Should not show truncation message when size equals maxSize
-        assertFalse(result.contains("truncated"));
-        assertTrue(result.contains("Last 5 lines"));
-        verify(environment).getProperty("logging.file.name");
-    }
-
-    @Test
-    @DisplayName("Should handle file size just one byte over maxSize")
-    void getRecentLogs_WhenFileSizeOneByteOverMaxSize_ReturnsTruncatedContent() throws IOException {
-        // Arrange
-        Path testFile = tempDir.resolve("test.log");
-        createTestFile(testFile, 20, "Line ");
-        
-        LogTailer logTailer = new LogTailer();
-        long exactSize = Files.size(testFile);
-        // Set maxSize to be smaller than the actual file size
-        logTailer.setMaxSize(DataSize.ofBytes(10));
-        properties.getTools().setLogTailer(logTailer);
-        
-        when(environment.getProperty("logging.file.name")).thenReturn(testFile.toString());
-
-        // Act
-        String result = applicationLogTool.getRecentLogs(5);
-
-        // Assert
-        // Should show truncation message when size exceeds maxSize
-        assertTrue(result.contains("truncated"));
         verify(environment).getProperty("logging.file.name");
     }
 

--- a/src/test/java/dev/scaffoldkit/mcp/tools/ApplicationLogToolTest.java
+++ b/src/test/java/dev/scaffoldkit/mcp/tools/ApplicationLogToolTest.java
@@ -39,7 +39,7 @@ class ApplicationLogToolTest {
         properties = new McpProperties();
         // Ensure the tools object is properly initialized
         properties.setTools(new McpProperties.Tools());
-        applicationLogTool = new ApplicationLogTool(properties, environment);
+        applicationLogTool = new ApplicationLogTool(environment);
     }
 
     @Test


### PR DESCRIPTION
﻿Return original implementation ideas now that we have good test coverage

fix: improve log tool efficiency by using backward reading instead of loading entire file

- Replace Files.readAllLines() with efficient backward reading using RandomAccessFile
- Remove maxSize check and misleading 'truncated' system note
- Stream-like approach that reads only what's needed from end of file
- Handle partial lines correctly when reading from middle of file
- Support both \n and \r\n line endings
- Update header to show actual number of lines returned

This resolves issues where large log files would cause memory problems
and eliminates confusing truncation messages that appeared when file
size exceeded maxSize even though we were returning the requested
number of lines.
